### PR TITLE
Add Smack list reordered and incl. audio link

### DIFF
--- a/trollpy/templates/add_smack.jinja2
+++ b/trollpy/templates/add_smack.jinja2
@@ -15,14 +15,195 @@
     </form>
     <ul>
     <table>
+
     <th>Level</th><th colspan="2">Phrase</th>
+    {# --------------------------------------------------------------------- #}
     {% for killscore in killscore %}
+    {% if killscore.killscore_id == 8 %}
     <tr>
         <td>{{ killscore.killscore_id }}</td>
         <td>{{ killscore.statement }}</td>
         <td><a href="/delete/{{ killscore.id }}">Delete</a></td>
     </tr>
+    {% endif %}
     {% endfor %}
+
+    {# --------------------------------------------------------------------- #}
+    {% for killscore in killscore %}
+    {% if killscore.killscore_id == 7 %}
+    <tr>
+        <td>{{ killscore.killscore_id }}</td>
+        <td>{{ killscore.statement }}</td>
+        <td><a href="/delete/{{ killscore.id }}">Delete</a></td>
+    </tr>
+    {% endif %}
+    {% endfor %}
+
+    {# --------------------------------------------------------------------- #}
+    {% for killscore in killscore %}
+    {% if killscore.killscore_id == 6 %}
+    <tr>
+        <td>{{ killscore.killscore_id }}</td>
+        <td>{{ killscore.statement }}</td>
+        <td><a href="/delete/{{ killscore.id }}">Delete</a></td>
+    </tr>
+    {% endif %}
+    {% endfor %}
+
+    {# --------------------------------------------------------------------- #}
+    {% for killscore in killscore %}
+    {% if killscore.killscore_id == 5 %}
+    <tr>
+        <td>{{ killscore.killscore_id }}</td>
+        <td>{{ killscore.statement }}</td>
+        <td><a href="/delete/{{ killscore.id }}">Delete</a></td>
+    </tr>
+    {% endif %}
+    {% endfor %}
+
+    {# --------------------------------------------------------------------- #}
+    {% for killscore in killscore %}
+    {% if killscore.killscore_id == 4 %}
+    <tr>
+        <td>{{ killscore.killscore_id }}</td>
+        <td>{{ killscore.statement }}</td>
+        <td><a href="/delete/{{ killscore.id }}">Delete</a></td>
+    </tr>
+    {% endif %}
+    {% endfor %}
+
+    {# --------------------------------------------------------------------- #}
+    {% for killscore in killscore %}
+    {% if killscore.killscore_id == 3 %}
+    <tr>
+        <td>{{ killscore.killscore_id }}</td>
+        <td>{{ killscore.statement }}</td>
+        <td><a href="/delete/{{ killscore.id }}">Delete</a></td>
+    </tr>
+    {% endif %}
+    {% endfor %}
+
+    {# --------------------------------------------------------------------- #}
+    {% for killscore in killscore %}
+    {% if killscore.killscore_id == 2 %}
+    <tr>
+        <td>{{ killscore.killscore_id }}</td>
+        <td>{{ killscore.statement }}</td>
+        <td><a href="/delete/{{ killscore.id }}">Delete</a></td>
+    </tr>
+    {% endif %}
+    {% endfor %}
+
+    {# --------------------------------------------------------------------- #}
+    {% for killscore in killscore %}
+    {% if killscore.killscore_id == 1 %}
+    <tr>
+        <td>{{ killscore.killscore_id }}</td>
+        <td>{{ killscore.statement }}</td>
+        <td><a href="/delete/{{ killscore.id }}">Delete</a></td>
+    </tr>
+    {% endif %}
+    {% endfor %}
+
+    {# --------------------------------------------------------------------- #}
+    {% for killscore in killscore %}
+    {% if killscore.killscore_id == 0 %}
+    <tr>
+        <td>{{ killscore.killscore_id }}</td>
+        <td>{{ killscore.statement }}</td>
+        <td><a href="/delete/{{ killscore.id }}">Delete</a></td>
+    </tr>
+    {% endif %}
+    {% endfor %}
+
+    {# --------------------------------------------------------------------- #}
+    {% for killscore in killscore %}
+    {% if killscore.killscore_id == -1 %}
+    <tr>
+        <td>{{ killscore.killscore_id }}</td>
+        <td>{{ killscore.statement }}</td>
+        <td><a href="/delete/{{ killscore.id }}">Delete</a></td>
+    </tr>
+    {% endif %}
+    {% endfor %}
+
+    {# --------------------------------------------------------------------- #}
+    {% for killscore in killscore %}
+    {% if killscore.killscore_id == -2 %}
+    <tr>
+        <td>{{ killscore.killscore_id }}</td>
+        <td>{{ killscore.statement }}</td>
+        <td><a href="/delete/{{ killscore.id }}">Delete</a></td>
+    </tr>
+    {% endif %}
+    {% endfor %}
+
+    {# --------------------------------------------------------------------- #}
+    {% for killscore in killscore %}
+    {% if killscore.killscore_id == -3 %}
+    <tr>
+        <td>{{ killscore.killscore_id }}</td>
+        <td>{{ killscore.statement }}</td>
+        <td><a href="/delete/{{ killscore.id }}">Delete</a></td>
+    </tr>
+    {% endif %}
+    {% endfor %}
+
+    {# --------------------------------------------------------------------- #}
+    {% for killscore in killscore %}
+    {% if killscore.killscore_id == -4 %}
+    <tr>
+        <td>{{ killscore.killscore_id }}</td>
+        <td>{{ killscore.statement }}</td>
+        <td><a href="/delete/{{ killscore.id }}">Delete</a></td>
+    </tr>
+    {% endif %}
+    {% endfor %}
+
+    {# --------------------------------------------------------------------- #}
+    {% for killscore in killscore %}
+    {% if killscore.killscore_id == -5 %}
+    <tr>
+        <td>{{ killscore.killscore_id }}</td>
+        <td>{{ killscore.statement }}</td>
+        <td><a href="/delete/{{ killscore.id }}">Delete</a></td>
+    </tr>
+    {% endif %}
+    {% endfor %}
+
+    {# --------------------------------------------------------------------- #}
+    {% for killscore in killscore %}
+    {% if killscore.killscore_id == -6 %}
+    <tr>
+        <td>{{ killscore.killscore_id }}</td>
+        <td>{{ killscore.statement }}</td>
+        <td><a href="/delete/{{ killscore.id }}">Delete</a></td>
+    </tr>
+    {% endif %}
+    {% endfor %}
+
+    {# --------------------------------------------------------------------- #}
+    {% for killscore in killscore %}
+    {% if killscore.killscore_id == -7 %}
+    <tr>
+        <td>{{ killscore.killscore_id }}</td>
+        <td>{{ killscore.statement }}</td>
+        <td><a href="/delete/{{ killscore.id }}">Delete</a></td>
+    </tr>
+    {% endif %}
+    {% endfor %}
+
+    {# --------------------------------------------------------------------- #}
+    {% for killscore in killscore %}
+    {% if killscore.killscore_id == -8 %}
+    <tr>
+        <td>{{ killscore.killscore_id }}</td>
+        <td>{{ killscore.statement }}</td>
+        <td><a href="/delete/{{ killscore.id }}">Delete</a></td>
+    </tr>
+    {% endif %}
+    {% endfor %}
+
     </table>
 {% else %}
 <p>You must be an admin to view this page.</p>

--- a/trollpy/templates/add_smack.jinja2
+++ b/trollpy/templates/add_smack.jinja2
@@ -22,7 +22,8 @@
     {% if killscore.killscore_id == 8 %}
     <tr>
         <td>{{ killscore.killscore_id }}</td>
-        <td>{{ killscore.statement }}</td>
+        <td>{{ killscore.statement }}
+        <a href="/mp3/{{ killscore.id }}"> 🔊 </a></td>
         <td><a href="/delete/{{ killscore.id }}">Delete</a></td>
     </tr>
     {% endif %}
@@ -33,7 +34,8 @@
     {% if killscore.killscore_id == 7 %}
     <tr>
         <td>{{ killscore.killscore_id }}</td>
-        <td>{{ killscore.statement }}</td>
+        <td>{{ killscore.statement }}
+        <a href="/mp3/{{ killscore.id }}"> 🔊 </a></td>
         <td><a href="/delete/{{ killscore.id }}">Delete</a></td>
     </tr>
     {% endif %}
@@ -44,7 +46,8 @@
     {% if killscore.killscore_id == 6 %}
     <tr>
         <td>{{ killscore.killscore_id }}</td>
-        <td>{{ killscore.statement }}</td>
+        <td>{{ killscore.statement }}
+        <a href="/mp3/{{ killscore.id }}"> 🔊 </a></td>
         <td><a href="/delete/{{ killscore.id }}">Delete</a></td>
     </tr>
     {% endif %}
@@ -55,7 +58,8 @@
     {% if killscore.killscore_id == 5 %}
     <tr>
         <td>{{ killscore.killscore_id }}</td>
-        <td>{{ killscore.statement }}</td>
+        <td>{{ killscore.statement }}
+        <a href="/mp3/{{ killscore.id }}"> 🔊 </a></td>
         <td><a href="/delete/{{ killscore.id }}">Delete</a></td>
     </tr>
     {% endif %}
@@ -66,7 +70,8 @@
     {% if killscore.killscore_id == 4 %}
     <tr>
         <td>{{ killscore.killscore_id }}</td>
-        <td>{{ killscore.statement }}</td>
+        <td>{{ killscore.statement }}
+        <a href="/mp3/{{ killscore.id }}"> 🔊 </a></td>
         <td><a href="/delete/{{ killscore.id }}">Delete</a></td>
     </tr>
     {% endif %}
@@ -77,7 +82,8 @@
     {% if killscore.killscore_id == 3 %}
     <tr>
         <td>{{ killscore.killscore_id }}</td>
-        <td>{{ killscore.statement }}</td>
+        <td>{{ killscore.statement }}
+        <a href="/mp3/{{ killscore.id }}"> 🔊 </a></td>
         <td><a href="/delete/{{ killscore.id }}">Delete</a></td>
     </tr>
     {% endif %}
@@ -88,7 +94,8 @@
     {% if killscore.killscore_id == 2 %}
     <tr>
         <td>{{ killscore.killscore_id }}</td>
-        <td>{{ killscore.statement }}</td>
+        <td>{{ killscore.statement }}
+        <a href="/mp3/{{ killscore.id }}"> 🔊 </a></td>
         <td><a href="/delete/{{ killscore.id }}">Delete</a></td>
     </tr>
     {% endif %}
@@ -99,7 +106,8 @@
     {% if killscore.killscore_id == 1 %}
     <tr>
         <td>{{ killscore.killscore_id }}</td>
-        <td>{{ killscore.statement }}</td>
+        <td>{{ killscore.statement }}
+        <a href="/mp3/{{ killscore.id }}"> 🔊 </a></td>
         <td><a href="/delete/{{ killscore.id }}">Delete</a></td>
     </tr>
     {% endif %}
@@ -110,7 +118,8 @@
     {% if killscore.killscore_id == 0 %}
     <tr>
         <td>{{ killscore.killscore_id }}</td>
-        <td>{{ killscore.statement }}</td>
+        <td>{{ killscore.statement }}
+        <a href="/mp3/{{ killscore.id }}"> 🔊 </a></td>
         <td><a href="/delete/{{ killscore.id }}">Delete</a></td>
     </tr>
     {% endif %}
@@ -121,7 +130,8 @@
     {% if killscore.killscore_id == -1 %}
     <tr>
         <td>{{ killscore.killscore_id }}</td>
-        <td>{{ killscore.statement }}</td>
+        <td>{{ killscore.statement }}
+        <a href="/mp3/{{ killscore.id }}"> 🔊 </a></td>
         <td><a href="/delete/{{ killscore.id }}">Delete</a></td>
     </tr>
     {% endif %}
@@ -132,7 +142,8 @@
     {% if killscore.killscore_id == -2 %}
     <tr>
         <td>{{ killscore.killscore_id }}</td>
-        <td>{{ killscore.statement }}</td>
+        <td>{{ killscore.statement }}
+        <a href="/mp3/{{ killscore.id }}"> 🔊 </a></td>
         <td><a href="/delete/{{ killscore.id }}">Delete</a></td>
     </tr>
     {% endif %}
@@ -143,7 +154,8 @@
     {% if killscore.killscore_id == -3 %}
     <tr>
         <td>{{ killscore.killscore_id }}</td>
-        <td>{{ killscore.statement }}</td>
+        <td>{{ killscore.statement }}
+        <a href="/mp3/{{ killscore.id }}"> 🔊 </a></td>
         <td><a href="/delete/{{ killscore.id }}">Delete</a></td>
     </tr>
     {% endif %}
@@ -154,7 +166,8 @@
     {% if killscore.killscore_id == -4 %}
     <tr>
         <td>{{ killscore.killscore_id }}</td>
-        <td>{{ killscore.statement }}</td>
+        <td>{{ killscore.statement }}
+        <a href="/mp3/{{ killscore.id }}"> 🔊 </a></td>
         <td><a href="/delete/{{ killscore.id }}">Delete</a></td>
     </tr>
     {% endif %}
@@ -165,7 +178,8 @@
     {% if killscore.killscore_id == -5 %}
     <tr>
         <td>{{ killscore.killscore_id }}</td>
-        <td>{{ killscore.statement }}</td>
+        <td>{{ killscore.statement }}
+        <a href="/mp3/{{ killscore.id }}"> 🔊 </a></td>
         <td><a href="/delete/{{ killscore.id }}">Delete</a></td>
     </tr>
     {% endif %}
@@ -176,7 +190,8 @@
     {% if killscore.killscore_id == -6 %}
     <tr>
         <td>{{ killscore.killscore_id }}</td>
-        <td>{{ killscore.statement }}</td>
+        <td>{{ killscore.statement }}
+        <a href="/mp3/{{ killscore.id }}"> 🔊 </a></td>
         <td><a href="/delete/{{ killscore.id }}">Delete</a></td>
     </tr>
     {% endif %}
@@ -187,7 +202,8 @@
     {% if killscore.killscore_id == -7 %}
     <tr>
         <td>{{ killscore.killscore_id }}</td>
-        <td>{{ killscore.statement }}</td>
+        <td>{{ killscore.statement }}
+        <a href="/mp3/{{ killscore.id }}"> 🔊 </a></td>
         <td><a href="/delete/{{ killscore.id }}">Delete</a></td>
     </tr>
     {% endif %}
@@ -198,7 +214,8 @@
     {% if killscore.killscore_id == -8 %}
     <tr>
         <td>{{ killscore.killscore_id }}</td>
-        <td>{{ killscore.statement }}</td>
+        <td>{{ killscore.statement }}
+        <a href="/mp3/{{ killscore.id }}"> 🔊 </a></td>
         <td><a href="/delete/{{ killscore.id }}">Delete</a></td>
     </tr>
     {% endif %}


### PR DESCRIPTION
I've edited `add_smack.jinja2` to reorder the list and display a small speaker icon which sends you to the smack talks corresponding mp3 route.  There should be a better way to do this with a jinja2 for loop, maybe like in range -8:8 (?) but I wasn't sure how at the time and just slapped it together with this good ole copy and paste method.